### PR TITLE
fix: prevent potential MEA hang when too many traces are processed

### DIFF
--- a/cv/components/mea.py
+++ b/cv/components/mea.py
@@ -22,13 +22,14 @@ import resource
 import sys
 import time
 import zipfile
+from queue import Empty, Full
 
 from aux.common import NestedLoop, kill_launches, wait_for_launches
 from components import BUSY_WAITING_INTERVAL, ERROR_TRACE_SOURCES
 from components.component import Component, Tool
-from mea.core import convert_error_trace, compare_error_traces, is_equivalent, ConversionFunction, \
-    DEFAULT_CONVERSION_FUNCTION, DEFAULT_COMPARISON_FUNCTION, CACHED_CONVERSION_FUNCTIONS, \
-    DEFAULT_SIMILARITY_THRESHOLD, TAG_CONVERSION_FUNCTION, TAG_COMPARISON_FUNCTION
+from mea.core import convert_error_trace, compare_error_traces, is_equivalent, DEFAULT_CONVERSION_FUNCTION, \
+    DEFAULT_COMPARISON_FUNCTION, CACHED_CONVERSION_FUNCTIONS, \
+    DEFAULT_SIMILARITY_THRESHOLD, TAG_CONVERSION_FUNCTION, TAG_COMPARISON_FUNCTION, ConversionFunction
 from mea.et import import_error_trace
 from models.tags import Tag, ComponentName, Extension, WitnessType, Resource
 
@@ -42,6 +43,8 @@ TAG_UNZIP = "unzip"
 TAG_DRY_RUN = "dry run"
 TAG_SOURCE_DIR = "source dir"
 TAG_PROCESSED_TRACE = "cet"
+
+BUSY_WAITING_MEA = 0.1  # MEA subprocesses usually finish quickly.
 
 DO_NOT_FILTER = "do not filter"
 
@@ -128,13 +131,21 @@ class MEA(Component):
                                                                             queue))
                             process_pool[i].start()
                             raise NestedLoop
-                    time.sleep(BUSY_WAITING_INTERVAL)
+                    time.sleep(BUSY_WAITING_MEA)
             except NestedLoop:
                 pass
             except Exception as exception:
                 self.logger.error(f"Could not filter traces: {exception}", exc_info=True)
                 kill_launches(process_pool)
 
+        counter = 0
+        while any(p and p.is_alive() for p in process_pool):
+            # Ensure all processes pushed data to the queue before calling join().
+            self.__drain_processing_queue(queue, converted_error_traces, memory_usage_all)
+            time.sleep(BUSY_WAITING_MEA)
+            if counter and counter % 10 == 0:
+                self.logger.debug(f"Waiting in a loop for {counter / 10}s.")
+            counter += 1
         wait_for_launches(process_pool)
         self.__drain_processing_queue(queue, converted_error_traces, memory_usage_all)
         self.__compute_max_memory_usage(memory_usage_all)
@@ -184,7 +195,7 @@ class MEA(Component):
                                     args=(error_trace_file,))
                                 process_pool[i].start()
                                 raise NestedLoop
-                        time.sleep(0.1)
+                        time.sleep(BUSY_WAITING_MEA)
                 except NestedLoop:
                     pass
                 except Exception as exception:
@@ -245,11 +256,19 @@ class MEA(Component):
                                             error_trace_file)
         if queue:
             user_time, system_time, memory = resource.getrusage(resource.RUSAGE_SELF)[0:3]
-            queue.put({
-                Resource.CPU_TIME: float(user_time + system_time),
-                Resource.MEMORY_USAGE: int(memory) * 1024,
-                TAG_PROCESSED_TRACE: [error_trace_file, converted_error_trace]
-            })
+            proc_elem = {
+                    Resource.CPU_TIME: float(user_time + system_time),
+                    Resource.MEMORY_USAGE: int(memory) * 1024
+            }
+            if parsed_error_trace:
+                proc_elem[TAG_PROCESSED_TRACE] = [error_trace_file, converted_error_trace]
+            try:
+                # Try to put an element into the queue within the specified timeout.
+                # If the queue is full or blocked (e.g., error trace too large), offload to file.
+                queue.put(proc_elem, timeout=BUSY_WAITING_INTERVAL)
+            except Full:
+                self.logger.debug(f"Cannot put trace into queue (size {len(converted_error_trace)}), offloading.")
+                raise NotImplementedError("Implement offloading to a file.")
             sys.exit(0)
         else:
             return bool(parsed_error_trace), parsed_error_trace.get('type', WitnessType.VIOLATION)
@@ -280,6 +299,9 @@ class MEA(Component):
     def __print_trace_archive(self, error_trace_file_name: str, witness_type=WitnessType.VIOLATION):
         json_trace_name, source_files, converted_traces_files = \
             self.__get_aux_file_names(error_trace_file_name)
+        if any(not os.path.isfile(file_path) for file_path in [json_trace_name, source_files, converted_traces_files]):
+            # Sanity check: skip broken results to avoid corrupting output.
+            return
         archive_name = error_trace_file_name[:-len(Extension.GRAPHML)] + Extension.ARCHIVE
         archive_name_base = os.path.basename(archive_name)
         if self.is_standalone:
@@ -405,13 +427,17 @@ class MEA(Component):
     def __drain_processing_queue(self, queue: multiprocessing.Queue,
                                  converted_error_traces: dict,
                                  memory_usage_all: list):
-        while not queue.empty():
-            proc_result = queue.get()
-            memory_usage_all.append(proc_result.get(Resource.MEMORY_USAGE, 0))
-            self.cpu_time += proc_result.get(Resource.CPU_TIME, 0.0)
-            cet = proc_result.get(TAG_PROCESSED_TRACE, [])
-            if cet and len(cet) == 2 and cet[0] and cet[1]:
-                converted_error_traces[cet[0]] = cet[1]
+        # Iterate over elements in the queue until it is empty.
+        while True:
+            try:
+                proc_result = queue.get_nowait()
+                memory_usage_all.append(proc_result.get(Resource.MEMORY_USAGE, 0))
+                self.cpu_time += proc_result.get(Resource.CPU_TIME, 0.0)
+                cet = proc_result.get(TAG_PROCESSED_TRACE, [])
+                if cet and len(cet) == 2:
+                    converted_error_traces[cet[0]] = cet[1]
+            except Empty:
+                break
 
     def __compute_max_memory_usage(self, memory_usage_all: list):
         children_memory = 0

--- a/cv/components/mea.py
+++ b/cv/components/mea.py
@@ -41,6 +41,7 @@ TAG_CLEAN = "clean"
 TAG_UNZIP = "unzip"
 TAG_DRY_RUN = "dry run"
 TAG_SOURCE_DIR = "source dir"
+TAG_PROCESSED_TRACE = "cet"
 
 DO_NOT_FILTER = "do not filter"
 
@@ -106,8 +107,9 @@ class MEA(Component):
 
         start_time = time.time()
         process_pool = []
+        memory_usage_all = []
         queue = multiprocessing.Queue()
-        converted_error_traces = multiprocessing.Manager().dict()
+        converted_error_traces = {}
         for i in range(self.parallel_processes):
             process_pool.append(None)
         for error_trace_file in self.error_traces:
@@ -121,10 +123,12 @@ class MEA(Component):
                             process_pool[i] = multiprocessing.Process(target=self.__process_trace,
                                                                       name=error_trace_file,
                                                                       args=(error_trace_file,
-                                                                            converted_error_traces,
                                                                             queue))
                             process_pool[i].start()
                             raise NestedLoop
+                    else:
+                        if not queue.empty():
+                            self.__drain_processing_queue(queue, converted_error_traces, memory_usage_all)
                     time.sleep(BUSY_WAITING_INTERVAL)
             except NestedLoop:
                 pass
@@ -133,7 +137,8 @@ class MEA(Component):
                 kill_launches(process_pool)
 
         wait_for_launches(process_pool)
-        self.__count_resource_usage(queue)
+        self.__drain_processing_queue(queue, converted_error_traces, memory_usage_all)
+        self.__compute_max_memory_usage(memory_usage_all)
         self.package_processing_time = time.time() - start_time
 
         # Need to sort traces for deterministic results.
@@ -211,22 +216,20 @@ class MEA(Component):
         is_exported = False
         witness_type = WitnessType.VIOLATION
         for error_trace_file in self.error_traces:
-            converted_error_traces = {}
-            is_exported, witness_type = self.__process_trace(error_trace_file,
-                                                             converted_error_traces)
+            is_exported, witness_type = self.__process_trace(error_trace_file)
             if is_exported:
                 self.__print_trace_archive(error_trace_file, witness_type)
         self.memory = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss) * 1024
         return is_exported, witness_type
 
-    def __process_trace(self, error_trace_file: str, converted_error_traces: dict,
-                        queue: multiprocessing.Queue = None):
+    def __process_trace(self, error_trace_file: str, queue: multiprocessing.Queue = None):
         # TODO: if we receive several witnesses they are considered to be violation witnesses only.
         if queue and not self.is_standalone:
             supported_types = {WitnessType.VIOLATION}
         else:
             supported_types = {WitnessType.VIOLATION, WitnessType.CORRECTNESS}
         parsed_error_trace = self.__parse_trace(error_trace_file, supported_types)
+        converted_error_trace = []
         if parsed_error_trace:
             self.__process_parsed_trace(parsed_error_trace)
             if self.clean:
@@ -241,13 +244,12 @@ class MEA(Component):
                                                         self.conversion_function_args)
             self.__print_parsed_error_trace(parsed_error_trace, converted_error_trace,
                                             error_trace_file)
-            converted_error_traces[error_trace_file] = converted_error_trace
-
         if queue:
             user_time, system_time, memory = resource.getrusage(resource.RUSAGE_SELF)[0:3]
             queue.put({
                 Resource.CPU_TIME: float(user_time + system_time),
-                Resource.MEMORY_USAGE: int(memory) * 1024
+                Resource.MEMORY_USAGE: int(memory) * 1024,
+                TAG_PROCESSED_TRACE: [error_trace_file, converted_error_trace]
             })
             sys.exit(0)
         else:
@@ -401,13 +403,19 @@ class MEA(Component):
         converted_traces_files = common_part + CONVERTED_ERROR_TRACES
         return json_trace_name, source_files, converted_traces_files
 
-    def __count_resource_usage(self, queue: multiprocessing.Queue):
-        memory_usage_all = []
-        children_memory = 0
+    def __drain_processing_queue(self, queue: multiprocessing.Queue,
+                                 converted_error_traces: dict,
+                                 memory_usage_all: list):
         while not queue.empty():
-            resources = queue.get()
-            memory_usage_all.append(resources.get(Resource.MEMORY_USAGE, 0))
-            self.cpu_time += resources.get(Resource.CPU_TIME, 0.0)
+            proc_result = queue.get()
+            memory_usage_all.append(proc_result.get(Resource.MEMORY_USAGE, 0))
+            self.cpu_time += proc_result.get(Resource.CPU_TIME, 0.0)
+            cet = proc_result.get(TAG_PROCESSED_TRACE, [])
+            if cet and len(cet) == 2 and cet[0] and cet[1]:
+                converted_error_traces[cet[0]] = cet[1]
+
+    def __compute_max_memory_usage(self, memory_usage_all: list):
+        children_memory = 0
         for memory_usage in sorted(memory_usage_all)[:self.parallel_processes]:
             children_memory += memory_usage
         process_memory = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss) * 1024

--- a/cv/components/mea.py
+++ b/cv/components/mea.py
@@ -268,7 +268,7 @@ class MEA(Component):
                 queue.put(proc_elem, timeout=BUSY_WAITING_INTERVAL)
             except Full:
                 self.logger.debug(f"Cannot put trace into queue (size {len(converted_error_trace)}), offloading.")
-                raise NotImplementedError("Implement offloading to a file.")
+                raise NotImplementedError("Implement offloading to a file.")  # pylint: disable=raise-missing-from
             sys.exit(0)
         else:
             return bool(parsed_error_trace), parsed_error_trace.get('type', WitnessType.VIOLATION)

--- a/cv/components/mea.py
+++ b/cv/components/mea.py
@@ -119,6 +119,8 @@ class MEA(Component):
                         if process_pool[i] and not process_pool[i].is_alive():
                             process_pool[i].join()
                             process_pool[i] = None
+                            if not queue.empty():
+                                self.__drain_processing_queue(queue, converted_error_traces, memory_usage_all)
                         if not process_pool[i]:
                             process_pool[i] = multiprocessing.Process(target=self.__process_trace,
                                                                       name=error_trace_file,
@@ -126,9 +128,6 @@ class MEA(Component):
                                                                             queue))
                             process_pool[i].start()
                             raise NestedLoop
-                    else:
-                        if not queue.empty():
-                            self.__drain_processing_queue(queue, converted_error_traces, memory_usage_all)
                     time.sleep(BUSY_WAITING_INTERVAL)
             except NestedLoop:
                 pass
@@ -144,7 +143,7 @@ class MEA(Component):
         # Need to sort traces for deterministic results.
         # Moreover, first traces are usually more "simpler".
         sorted_traces = {}
-        for trace in converted_error_traces.keys():
+        for trace in converted_error_traces:
             identifier = re.search(rf'witness(.*){Extension.GRAPHML}', trace).group(1)
             key = identifier
             if identifier.isdigit():

--- a/cv/components/mea.py
+++ b/cv/components/mea.py
@@ -247,7 +247,7 @@ class MEA(Component):
             self.logger.debug(f"Trace '{error_trace_file}' has been parsed")
 
             if parsed_error_trace.get('type') == WitnessType.CORRECTNESS:
-                conversion_function = ConversionFunction.FULL
+                conversion_function = ConversionFunction.CONDITIONS
             else:
                 conversion_function = self.conversion_function
             converted_error_trace = convert_error_trace(parsed_error_trace, conversion_function,

--- a/cv/models/verification_result.py
+++ b/cv/models/verification_result.py
@@ -352,7 +352,7 @@ class VerificationResults:
         """
         start_time_cpu = time.process_time()
         start_wall_time = time.time()
-        traces = glob.glob(f"{launch_dir}/witness*")
+        traces = glob.glob(f"{launch_dir}/witness*{Extension.GRAPHML}")
         mea = MEA(self.config, traces, install_dir, self.rule, result_dir, remove_prefixes=remove_src_prefixes)
         self.filtered_traces = len(mea.filter())
         if self.filtered_traces:


### PR DESCRIPTION
If a verification result produces a large number of error traces,
the per-process MEA resource queue may overflow, causing the entire
process to hang.